### PR TITLE
优化embed_tokens设备选择，遵循配置文件设置

### DIFF
--- a/ktransformers/models/custom_modeling_deepseek_v2.py
+++ b/ktransformers/models/custom_modeling_deepseek_v2.py
@@ -58,8 +58,10 @@ class KDeepseekV2ForCausalLM(DeepseekV2PreTrainedModel):
         features = []
         for i in range(batch.batch_size):
             tokens = batch.minibatch.tokens.contiguous()
+            # 获取embed_tokens的设备，遵循配置文件设置
+            embed_device = next(self.model.embed_tokens.parameters()).device
             feature = (
-                self.model.embed_tokens(tokens.to(torch.device('cpu')))
+                self.model.embed_tokens(tokens.to(embed_device))
                 .to(torch.bfloat16)
                 .to(device=device)
             )

--- a/ktransformers/models/custom_modeling_deepseek_v3.py
+++ b/ktransformers/models/custom_modeling_deepseek_v3.py
@@ -62,8 +62,10 @@ class KDeepseekV3ForCausalLM(DeepseekV3PreTrainedModel):
         features = []
         for i in range(batch.batch_size):
             tokens = batch.minibatch.tokens.contiguous()
+            # 获取embed_tokens的设备，遵循配置文件设置
+            embed_device = next(self.model.embed_tokens.parameters()).device
             feature = (
-                self.model.embed_tokens(tokens.to(torch.device('cpu')))
+                self.model.embed_tokens(tokens.to(embed_device))
                 .to(torch.bfloat16)
                 .to(device=device)
             )

--- a/ktransformers/models/custom_modeling_qwen3_moe.py
+++ b/ktransformers/models/custom_modeling_qwen3_moe.py
@@ -49,8 +49,10 @@ class KQwen3MoeForCausalLM(Qwen3MoePreTrainedModel):
         features = []
         for i in range(batch.batch_size):
             tokens = batch.minibatch.tokens.contiguous()
+            # 获取embed_tokens的设备，遵循配置文件设置
+            embed_device = next(self.model.embed_tokens.parameters()).device
             feature = (
-                self.model.embed_tokens(tokens.to(torch.device('cpu')))
+                self.model.embed_tokens(tokens.to(embed_device))
                 .to(torch.bfloat16)
                 .to(device=device)
             )


### PR DESCRIPTION
- 在DeepSeek V2、V3和Qwen3 MOE模型中，将embed_tokens的设备选择从固定CPU改为根据模型参数设备
- 提高了设备利用率和性能一致性